### PR TITLE
Use dashes to separate words in command-line arguments

### DIFF
--- a/ros_command/build_tool.py
+++ b/ros_command/build_tool.py
@@ -209,7 +209,7 @@ def get_package_selection_args(argv, build_type, pkg_name):
     parser = argparse.ArgumentParser()
     parser.add_argument('--this', action='store_true')
     parser.add_argument('-n', '--no-deps', action='store_true')
-    parser.add_argument('-s', '--skip_packages', nargs='+')
+    parser.add_argument('-s', '--skip-packages', nargs='+')
     parser.add_argument('include_packages', metavar='include_package', nargs='*')
     args, remaining_argv = parser.parse_known_args(argv)
 

--- a/ros_command/commands/rosbuild.py
+++ b/ros_command/commands/rosbuild.py
@@ -11,9 +11,9 @@ async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--continue-on-failure', action='store_true')
     parser.add_argument('-j', '--jobs', type=int)
-    parser.add_argument('-b', '--cmake_build_type')
+    parser.add_argument('-b', '--cmake-build-type')
     parser.add_argument('-t', '--test', action='store_true')
-    parser.add_argument('-g', '--toggle_graphics', action='store_true')
+    parser.add_argument('-g', '--toggle-graphics', action='store_true')
     args, unknown_args = parser.parse_known_args()
 
     build_type, workspace_root = get_workspace_root()

--- a/ros_command/commands/rosclean.py
+++ b/ros_command/commands/rosclean.py
@@ -10,9 +10,9 @@ from ros_command.util import sizeof_fmt
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-y', '--yes_to_all', action='store_true')
-    parser.add_argument('-c', '--just_checking', action='store_true')
-    parser.add_argument('-n', '--no_sizes', action='store_true')
+    parser.add_argument('-y', '--yes-to-all', '--no-confirm', action='store_true')
+    parser.add_argument('-c', '--just-checking', action='store_true')
+    parser.add_argument('-n', '--no-sizes', action='store_true')
     parser.add_argument('packages', metavar='package', nargs='*')
     args, unknown_args = parser.parse_known_args()
     if args.packages:


### PR DESCRIPTION
E.g. `--skip-packages` instead of `--skip_packages`. This is the most commonly used convention.