### PR TITLE
fix asyncio in python 3.7+

### DIFF
--- a/ros_command/command_lib.py
+++ b/ros_command/command_lib.py
@@ -37,8 +37,8 @@ async def run(command, stdout_callback=None, stderr_callback=None, cwd=None):
     if stderr_callback is None:
         stderr_callback = _default_stderr_callback
 
-    await asyncio.wait([_read_stream(process.stdout, stdout_callback),
-                        _read_stream(process.stderr, stderr_callback)])
+    await asyncio.wait([asyncio.create_task(_read_stream(process.stdout, stdout_callback)),
+                        asyncio.create_task(_read_stream(process.stderr, stderr_callback))])
 
     return await process.wait()
 


### PR DESCRIPTION
I applied the fix from https://github.com/catkin/catkin_tools/pull/741 :-)
If you want to stay compatible [with Ubuntu bionic](https://packages.ubuntu.com/bionic/python3-minimal) in your upstream, you will need a similar conditional.