### PR TITLE
Fixes for ROS-O, debian testing, and uncommon builds

### DIFF
--- a/src/ros_command/command_lib.py
+++ b/src/ros_command/command_lib.py
@@ -1,6 +1,10 @@
 import asyncio
 from asyncio import create_subprocess_exec
 from asyncio.subprocess import DEVNULL, PIPE
+import subprocess
+
+import sys
+import os
 
 import click
 
@@ -25,6 +29,11 @@ def _default_stderr_callback(line):
     """Default callback for stderr that prints to stdout in red."""
     click.secho(line, fg='red', nl=False)
 
+def get_overlayed_command(command):
+    cmds = subprocess.run(['which', '-a', command], stdout=PIPE, text=True).stdout
+    cmds = cmds.splitlines()
+    executing_path = os.path.dirname(os.path.realpath(sys.argv[0]))
+    return next(r for r in cmds if not r.startswith(executing_path))
 
 async def run(command, stdout_callback=None, stderr_callback=None, cwd=None):
     """Run a command (array of strings) and process its output with callbacks."""

--- a/src/ros_command/command_lib.py
+++ b/src/ros_command/command_lib.py
@@ -29,11 +29,13 @@ def _default_stderr_callback(line):
     """Default callback for stderr that prints to stdout in red."""
     click.secho(line, fg='red', nl=False)
 
+
 def get_overlayed_command(command):
     cmds = subprocess.run(['which', '-a', command], stdout=PIPE, text=True).stdout
     cmds = cmds.splitlines()
     executing_path = os.path.dirname(os.path.realpath(sys.argv[0]))
     return next(r for r in cmds if not r.startswith(executing_path))
+
 
 async def run(command, stdout_callback=None, stderr_callback=None, cwd=None):
     """Run a command (array of strings) and process its output with callbacks."""

--- a/src/ros_command/command_lib.py
+++ b/src/ros_command/command_lib.py
@@ -1,10 +1,8 @@
 import asyncio
 from asyncio import create_subprocess_exec
 from asyncio.subprocess import DEVNULL, PIPE
-import subprocess
-
+import pathlib
 import sys
-import os
 
 import click
 
@@ -28,13 +26,6 @@ def _default_stdout_callback(line):
 def _default_stderr_callback(line):
     """Default callback for stderr that prints to stdout in red."""
     click.secho(line, fg='red', nl=False)
-
-
-def get_overlayed_command(command):
-    cmds = subprocess.run(['which', '-a', command], stdout=PIPE, text=True).stdout
-    cmds = cmds.splitlines()
-    executing_path = os.path.dirname(os.path.realpath(sys.argv[0]))
-    return next(r for r in cmds if not r.startswith(executing_path))
 
 
 async def run(command, stdout_callback=None, stderr_callback=None, cwd=None):
@@ -76,3 +67,10 @@ async def get_output(command, cwd=None):
                     stderr_callback=lambda line: gather_callback(err, line))
 
     return ret, ''.join(out), ''.join(err)
+
+
+async def get_overlayed_command(command):
+    _, which_output, _ = await get_output(['which', '-a', command])
+    cmds = which_output.splitlines()
+    executing_folder_s = str(pathlib.Path(sys.argv[0]).parent)
+    return next(r for r in cmds if not r.startswith(executing_folder_s))

--- a/src/ros_command/commands/rosexecute.py
+++ b/src/ros_command/commands/rosexecute.py
@@ -39,8 +39,7 @@ async def main():
 
     command = []
     if version == 1:
-        rosrun = get_overlayed_command(f'ros{verb}')
-        command.append(rosrun)
+        command.append(await get_overlayed_command(f'ros{verb}'))
     else:
         command.append(f'/opt/ros/{distro}/bin/ros2')
         command.append(verb)

--- a/src/ros_command/commands/rosexecute.py
+++ b/src/ros_command/commands/rosexecute.py
@@ -4,7 +4,7 @@ import asyncio
 
 from betsy_ros import get_ros_version, get_workspace_root
 
-from ros_command.command_lib import run
+from ros_command.command_lib import run, get_overlayed_command
 from ros_command.completion import PackageCompleter
 from ros_command.packages import find_executables_in_package, find_launch_files_in_package
 
@@ -39,7 +39,8 @@ async def main():
 
     command = []
     if version == 1:
-        command.append(f'/opt/ros/{distro}/bin/ros{verb}')
+        rosrun = get_overlayed_command(f'ros{verb}')
+        command.append(rosrun)
     else:
         command.append(f'/opt/ros/{distro}/bin/ros2')
         command.append(verb)

--- a/src/ros_command/commands/roslaunch.py
+++ b/src/ros_command/commands/roslaunch.py
@@ -22,8 +22,7 @@ async def main():
 
     command = []
     if version == 1:
-        roslaunch = get_overlayed_command('roslaunch')
-        command.append(roslaunch)
+        command.append(await get_overlayed_command('roslaunch'))
     else:
         command.append(f'/opt/ros/{distro}/bin/ros2')
         command.append('launch')

--- a/src/ros_command/commands/roslaunch.py
+++ b/src/ros_command/commands/roslaunch.py
@@ -4,7 +4,7 @@ import asyncio
 
 from betsy_ros import get_ros_version, get_workspace_root
 
-from ros_command.command_lib import run
+from ros_command.command_lib import run, get_overlayed_command
 from ros_command.completion import PackageCompleter, LaunchArgCompleter, LaunchFileCompleter
 
 
@@ -22,7 +22,8 @@ async def main():
 
     command = []
     if version == 1:
-        command.append(f'/opt/ros/{distro}/bin/roslaunch')
+        roslaunch = get_overlayed_command('roslaunch')
+        command.append(roslaunch)
     else:
         command.append(f'/opt/ros/{distro}/bin/ros2')
         command.append('launch')

--- a/src/ros_command/commands/rosrun.py
+++ b/src/ros_command/commands/rosrun.py
@@ -4,7 +4,7 @@ import asyncio
 
 from betsy_ros import get_ros_version, get_workspace_root
 
-from ros_command.command_lib import run
+from ros_command.command_lib import run, get_overlayed_command
 from ros_command.completion import PackageCompleter, ExecutableNameCompleter
 
 
@@ -23,7 +23,8 @@ async def main(debug=False):
 
     command = []
     if version == 1:
-        command.append(f'/opt/ros/{distro}/bin/rosrun')
+        rosrun = get_overlayed_command('rosrun')
+        command.append(rosrun)
     else:
         command.append(f'/opt/ros/{distro}/bin/ros2')
         command.append('run')

--- a/src/ros_command/commands/rosrun.py
+++ b/src/ros_command/commands/rosrun.py
@@ -23,8 +23,7 @@ async def main(debug=False):
 
     command = []
     if version == 1:
-        rosrun = get_overlayed_command('rosrun')
-        command.append(rosrun)
+        command.append(await get_overlayed_command('rosrun'))
     else:
         command.append(f'/opt/ros/{distro}/bin/ros2')
         command.append('run')

--- a/src/ros_command/ros_command_setup.bash
+++ b/src/ros_command/ros_command_setup.bash
@@ -39,14 +39,16 @@ source_ros()
     fi
 }
 
-eval "$(register-python-argcomplete3 get_ros_directory)"
-eval "$(register-python-argcomplete3 rosaction)"
-eval "$(register-python-argcomplete3 rosbuild)"
-eval "$(register-python-argcomplete3 rosclean)"
-eval "$(register-python-argcomplete3 rosdebug)"
-eval "$(register-python-argcomplete3 rosdep_install)"
-eval "$(register-python-argcomplete3 rosexecute)"
-eval "$(register-python-argcomplete3 roslaunch)"
-eval "$(register-python-argcomplete3 rosmsg)"
-eval "$(register-python-argcomplete3 rosrun)"
-eval "$(register-python-argcomplete3 rossrv)"
+argcomplete=$(which register-python-argcomplete{,3})
+
+eval "$($argcomplete get_ros_directory)"
+eval "$($argcomplete rosaction)"
+eval "$($argcomplete rosbuild)"
+eval "$($argcomplete rosclean)"
+eval "$($argcomplete rosdebug)"
+eval "$($argcomplete rosdep_install)"
+eval "$($argcomplete rosexecute)"
+eval "$($argcomplete roslaunch)"
+eval "$($argcomplete rosmsg)"
+eval "$($argcomplete rosrun)"
+eval "$($argcomplete rossrv)"

--- a/src/ros_command/ros_command_setup.bash
+++ b/src/ros_command/ros_command_setup.bash
@@ -5,7 +5,7 @@
 # Attempt to implement roscd upstream: https://github.com/ros2/ros2cli/pull/75
 
 # Only define roscd when it is not defined, i.e. don't overwrite the ROS 1 version
-if ! $(type -t roscd) ; then
+if ! type -t roscd >/dev/null 2>&1; then
     roscd()
     {
         if [[ -z "${ROS_VERSION}" ]]; then


### PR DESCRIPTION
Trying out your new changes I noticed that you did not include [my previous round of fixes](https://github.com/MetroRobots/ros_command/compare/main...v4hn:ros_command:argcomplete) required on my Debian testing development machine.

I adapted the patches for current `main` and slightly reworked them, but I still need them to use the project at all.
Happy to discuss alternatives if you're unhappy with something.